### PR TITLE
Make possible to set custom collapsed title

### DIFF
--- a/demo/src/main/res/layout/activity_demo.xml
+++ b/demo/src/main/res/layout/activity_demo.xml
@@ -19,7 +19,8 @@
             android:layout_height="match_parent"
             android:theme="@style/AppTheme.AppBarOverlay"
             app:layout_scrollFlags="scroll|exitUntilCollapsed"
-            app:title="@string/title"
+            app:title="@string/title_long"
+            app:collapsedTitle="@string/title_short"
             app:expandedTitleTextAppearance="@style/TextAppearance.ExpandedTitle"
             app:maxLines="3"
             app:lineSpacingMultiplier="1.2">

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">Demo</string>
-    <string name="title">This is a long title text displayed in multiple lines.</string>
+    <string name="title_long">This is a long title text displayed in multiple lines.</string>
+    <string name="title_short">This is a long title…</string>
     <string name="loremipsum">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
         nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Duis autem vel eum iriure dolor in hendrerit in vulputate velit esse molestie consequat, vel illum dolore eu feugiat nulla facilisis at vero eros et accumsan et iusto odio dignissim qui blandit praesent luptatum zzril delenit augue duis dolore te feugait nulla facilisi. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat.</string>
     <string name="settings">Settings</string>

--- a/multiline-collapsingtoolbar/src/main/java/net/opacapp/multilinecollapsingtoolbar/CollapsingTextHelper.java
+++ b/multiline-collapsingtoolbar/src/main/java/net/opacapp/multilinecollapsingtoolbar/CollapsingTextHelper.java
@@ -122,6 +122,7 @@ final class CollapsingTextHelper {
     private int maxLines = 3;
     private float lineSpacingExtra = 0;
     private float lineSpacingMultiplier = 1;
+    private String mCustomCollapedTitle;
     // END MODIFICATION
 
     public CollapsingTextHelper(View view) {
@@ -462,7 +463,7 @@ final class CollapsingTextHelper {
         calculateUsingTextSize(mCollapsedTextSize);
 
         // BEGIN MODIFICATION: set mTextToDrawCollapsed and calculate width using it
-        mTextToDrawCollapsed = mTextToDraw;
+        mTextToDrawCollapsed = mCustomCollapedTitle == null ? mTextToDraw : mCustomCollapedTitle;
         float width = mTextToDrawCollapsed != null ?
             mTextPaint.measureText(mTextToDrawCollapsed, 0, mTextToDrawCollapsed.length()) : 0;
         // END MODIFICATION
@@ -955,5 +956,9 @@ final class CollapsingTextHelper {
 
     private static boolean rectEquals(Rect r, int left, int top, int right, int bottom) {
         return !(r.left != left || r.top != top || r.right != right || r.bottom != bottom);
+    }
+
+    void setCollapsedText(String text) {
+        mCustomCollapedTitle = text;
     }
 }

--- a/multiline-collapsingtoolbar/src/main/java/net/opacapp/multilinecollapsingtoolbar/CollapsingToolbarLayout.java
+++ b/multiline-collapsingtoolbar/src/main/java/net/opacapp/multilinecollapsingtoolbar/CollapsingToolbarLayout.java
@@ -238,6 +238,7 @@ public class CollapsingToolbarLayout extends FrameLayout {
         // BEGIN MODIFICATION: set the value of maxNumberOfLines attribute to the mCollapsingTextHelper
         TypedArray typedArray = context.obtainStyledAttributes(attrs, net.opacapp.multilinecollapsingtoolbar.R.styleable.CollapsingToolbarLayoutExtension, defStyleAttr, 0);
         mCollapsingTextHelper.setMaxLines(typedArray.getInteger(net.opacapp.multilinecollapsingtoolbar.R.styleable.CollapsingToolbarLayoutExtension_maxLines, 3));
+        mCollapsingTextHelper.setCollapsedText(typedArray.getString(net.opacapp.multilinecollapsingtoolbar.R.styleable.CollapsingToolbarLayoutExtension_collapsedTitle));
         mCollapsingTextHelper.setLineSpacingExtra(typedArray.getFloat(net.opacapp.multilinecollapsingtoolbar.R.styleable.CollapsingToolbarLayoutExtension_lineSpacingExtra, 0));
         mCollapsingTextHelper.setLineSpacingMultiplier(typedArray.getFloat(net.opacapp.multilinecollapsingtoolbar.R.styleable.CollapsingToolbarLayoutExtension_lineSpacingMultiplier, 1));
         typedArray.recycle();

--- a/multiline-collapsingtoolbar/src/main/res/values/collapsing_toolbar_attrs.xml
+++ b/multiline-collapsingtoolbar/src/main/res/values/collapsing_toolbar_attrs.xml
@@ -2,6 +2,7 @@
 <!--BEGIN MODIFICATION: Create an attribute for max line number-->
 <resources>
     <declare-styleable name="CollapsingToolbarLayoutExtension">
+        <attr name="collapsedTitle" format="string" />
         <attr name="maxLines" format="integer" />
         <attr name="lineSpacingExtra" format="float"/>
         <attr name="lineSpacingMultiplier" format="float"/>


### PR DESCRIPTION
Make possible to setup custom collapsed title when you don't want to this be set by system.

Usecase:
Expanded Header:
"John Smith Junior, CTO of awesome company"

Collapsed Header:
"John Smith" instead of "John Smith Junior, CTO..."