### PR TITLE
Library update to 28.0.0, compile and target to 28

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ adding a new dependency statement.
 
 ```gradle
 dependencies {
-    compile 'net.opacapp:multiline-collapsingtoolbar:27.1.1'
+    implementation 'net.opacapp:multiline-collapsingtoolbar:28.0.0'
 }
 ```
 
-The current version 27.1.1 of the library is based on the code and tested with the **Design Support
-Library version 27.1.1**.
+The current version 28.0.0 of the library is based on the code and tested with the **Design Support
+Library version 28.0.0**.
 We'll try to keep up to date with new support library versions as soon as possible, but please **do not expect this
 library to run with support versions other than that.**
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -13,7 +13,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:28.0.0'
-    compile 'com.android.support:design:28.0.0'
-    compile project(':multiline-collapsingtoolbar')
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
+    implementation project(':multiline-collapsingtoolbar')
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -13,7 +13,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:27.1.1'
-    compile 'com.android.support:design:27.1.1'
+    compile 'com.android.support:appcompat-v7:28.0.0'
+    compile 'com.android.support:design:28.0.0'
     compile project(':multiline-collapsingtoolbar')
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         applicationId "net.opacapp.multilinecollapsingtoolbar.demo"
         minSdkVersion 14
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Mar 27 20:13:09 CEST 2018
+#Tue Oct 16 12:16:29 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/multiline-collapsingtoolbar/build.gradle
+++ b/multiline-collapsingtoolbar/build.gradle
@@ -7,7 +7,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 27
         versionCode 11
-        versionName "27.1.1"
+        versionName "28.0.0"
     }
     buildTypes {
         release {
@@ -33,7 +33,7 @@ ext {
     siteUrl = 'https://github.com/opacapp/multiline-collapsingtoolbar'
     gitUrl = 'https://github.com/opacapp/multiline-collapsingtoolbar.git'
 
-    libraryVersion = '27.1.1'
+    libraryVersion = '28.0.0'
 
     developerId = 'opacapp'
     developerName = 'Web Opac App'
@@ -45,9 +45,9 @@ ext {
 }
 
 dependencies {
-    compile 'com.android.support:design:27.1.1'
-    compile 'com.android.support:support-v4:27.1.1'
-    compile 'com.android.support:appcompat-v7:27.1.1'
+    compile 'com.android.support:design:28.0.0'
+    compile 'com.android.support:support-v4:28.0.0'
+    compile 'com.android.support:appcompat-v7:28.0.0'
 }
 
 

--- a/multiline-collapsingtoolbar/build.gradle
+++ b/multiline-collapsingtoolbar/build.gradle
@@ -45,9 +45,9 @@ ext {
 }
 
 dependencies {
-    compile 'com.android.support:design:28.0.0'
-    compile 'com.android.support:support-v4:28.0.0'
-    compile 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
 }
 
 

--- a/multiline-collapsingtoolbar/build.gradle
+++ b/multiline-collapsingtoolbar/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 11
         versionName "28.0.0"
     }


### PR DESCRIPTION
Fixes #60 by updating the support library version to 28.0.0

This also updates the compileSdk and targetSdk from version 27 (8.1) to 28 (9.0).

---

Another change this adds is using `implementation` instead of `compile`. As I wrote in the last commit of this request:

> For quite some time now (gradle 3.0), gradle has added support for “api”
and “implementation” keywords instead of “compile” which enable one to
choose whether the library should propagate dependencies to its
dependents (api) or merely use it for its own purposes and not make them
available for modules depending on it (implementation).

> For the library, this might result in breaking changes for some
dependents of it as “implementation” no longer automatically adds the
support libraries used by the this library to their build path, making
them readily available for use in their app as well without defining
them as dependencies on their own.

If you decide that this is what you’re going for as well, fine. Otherwise, feel free to remove commit `8056290` before merging. 